### PR TITLE
widgets: Don't call `get_context` with kwargs

### DIFF
--- a/select2rocks/widgets.py
+++ b/select2rocks/widgets.py
@@ -36,7 +36,7 @@ class Select2TextInput(forms.TextInput):
         return context
 
     def render(self, name, value, attrs=None, **kwargs):
-        context = self.get_context(name, value, attrs=attrs or {}, **kwargs)
+        context = self.get_context(name, value, attrs=attrs or {})
 
         if django.VERSION >= (1, 10):
             return loader.render_to_string(


### PR DESCRIPTION
Django 1.11 `render` signature has an extra argument that `get_context`
doesn't allow.