### PR TITLE
widgets: Django 1.11 get_context compatibility

### DIFF
--- a/select2rocks/widgets.py
+++ b/select2rocks/widgets.py
@@ -25,7 +25,10 @@ class Select2TextInput(forms.TextInput):
             # Only add the value if it is non-empty
             context['value'] = self._format_value(value)
 
-        context['attrs'] = self.build_attrs(attrs)
+        if django.VERSION >= (1, 11):
+            context['attrs'] = self.build_attrs(self.attrs, attrs)
+        else:
+            context['attrs'] = self.build_attrs(attrs)
 
         for key, attr in context['attrs'].items():
             if attr == 1:


### PR DESCRIPTION
Without this commit, the following codes don't work with Django 1.11 : 
```python
CarContractWidget(
    url_name='common:autocomplete_contract_car',
    url_kwargs={'hrid': hrid},
    attrs={
        # add ajax helper to auto fill company or customer after select contract
        'data-get-contract-owner-url': reverse('cases:ajax_get_contract_owner')
    },
)
```
It's the problem of `attrs`.