### PR TITLE
setup.cfg: restrict upload to official pypi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[distutils]
+index-servers =
+  pypi
+


### PR DESCRIPTION
According to [zest's documentation](http://zestreleaser.readthedocs.io/en/latest/uploading.html#pypi-configuration-file-pypirc):

Note that since version 3.15, zest.releaser also looks for this
information in the setup.cfg if your package has that file. One way to
use this, is to restrict the servers that zest.releaser will ask you to
upload to.

This will prevent the package to be uploaded on private repositories.