### PR TITLE
widgets: use format_value instead of _format_value

### DIFF
--- a/select2rocks/widgets.py
+++ b/select2rocks/widgets.py
@@ -23,7 +23,7 @@ class Select2TextInput(forms.TextInput):
 
         if value is not None:
             # Only add the value if it is non-empty
-            context['value'] = self._format_value(value)
+            context['value'] = self.format_value(value)
 
         if django.VERSION >= (1, 11):
             context['attrs'] = self.build_attrs(self.attrs, attrs)


### PR DESCRIPTION
_format_value has been deprecated in django 1.10