### PR TITLE
Add compatibility with Django 4.+

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Next version
+============
+
+Add compatibility with Django 4
+
 django-select2-rocks v0.7.0 (2018-08-01)
 ========================================
 

--- a/select2rocks/widgets.py
+++ b/select2rocks/widgets.py
@@ -5,7 +5,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 from django.template import loader
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from select2rocks.settings import SELECT2_OPTIONS, SELECT2_ATTRS
 
@@ -86,7 +86,7 @@ class AjaxSelect2Widget(Select2TextInput):
         ctx = super(AjaxSelect2Widget, self).get_context(name, value, attrs)
         if 'placeholder' in options:
             # Resolve lazy ugettext
-            options['placeholder'] = force_text(options['placeholder'])
+            options['placeholder'] = force_str(options['placeholder'])
 
         ctx['select2_options'] = json.dumps(options)
         try:

--- a/testproj/testproj/testapp/forms.py
+++ b/testproj/testproj/testapp/forms.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import select2rocks
 

--- a/testproj/testproj/urls.py
+++ b/testproj/testproj/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 
 from testproj.testapp.views import BeachList, index, json_beaches
 
 urlpatterns = [
-    url(r'^$', index, name='index'),
-    url(r'^json/$', json_beaches, name='json_beaches'),
-    url(r'^restframework/$', BeachList.as_view(), name='rest_beach_list'),
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^$', index, name='index'),
+    re_path(r'^json/$', json_beaches, name='json_beaches'),
+    re_path(r'^restframework/$', BeachList.as_view(), name='rest_beach_list'),
+    re_path(r'^admin/', admin.site.urls),
 ]


### PR DESCRIPTION
force_str is deprecated in Django 3.0 and removed in Django 4.0
ugettext_lazy deprecated in Django 3.0 and removed in Django 4.0
django.conf.urls.url deprecated in Django 3.1 and removed in Django 4.0